### PR TITLE
HomeWork1. Unit tests

### DIFF
--- a/core/src/test/java/ru/androidlearning/core/DictionaryPresentationDataModelMapperTest.kt
+++ b/core/src/test/java/ru/androidlearning/core/DictionaryPresentationDataModelMapperTest.kt
@@ -1,0 +1,129 @@
+package ru.androidlearning.core
+
+import org.junit.Assert
+import org.junit.Test
+import ru.androidlearning.model.Meanings
+import ru.androidlearning.model.SearchDto
+import ru.androidlearning.model.Translation
+
+class DictionaryPresentationDataModelMapperTest {
+
+    private val currentTimeMs = System.currentTimeMillis()
+
+    private val meaningsOne = Meanings(
+        id = 1,
+        partOfSpeechCode = "n",
+        translation = Translation(
+            text = "TranslatedWord",
+            note = "Test note"
+        ),
+        previewUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=96&h=72",
+        imageUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=640&h=480",
+        transcription = "ˈteɪbl",
+        soundUrl = "//d2fmfepycn0xw0.cloudfront.net?gender=male&accent=british&text=table"
+    )
+
+    private val meaningsTwo = Meanings(
+        id = 2,
+        partOfSpeechCode = "n",
+        translation = Translation(
+            text = "TranslatedWord2",
+            note = "Test note2"
+        ),
+        previewUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=96&h=72",
+        imageUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=640&h=480",
+        transcription = "ˈteɪbl",
+        soundUrl = "//d2fmfepycn0xw0.cloudfront.net?gender=male&accent=british&text=table"
+    )
+
+    private val searchDtoActual = SearchDto(
+        id = 100,
+        word = "TestWord",
+        meanings = listOf(meaningsOne, meaningsTwo),
+        savedTime = currentTimeMs
+    )
+
+    private val dictionaryPresentationDataModelExpected = DictionaryPresentationDataModel(
+        translatedWords = listOf(
+            DictionaryPresentationDataModel.TranslatedWord(
+                id = 100,
+                word = "TestWord",
+                meaning = "TranslatedWord, TranslatedWord2",
+                transcription = "ˈteɪbl",
+                imageUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=640&h=480",
+                savedTime = currentTimeMs
+            )
+        )
+    )
+
+    private val dictionaryPresentationDataModelNotExpected = DictionaryPresentationDataModel(
+        translatedWords = listOf(
+            DictionaryPresentationDataModel.TranslatedWord(
+                id = 200,
+                word = "TestWord",
+                meaning = "TranslatedWord, TranslatedWord2",
+                transcription = "ˈteɪbl",
+                imageUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=640&h=480",
+                savedTime = currentTimeMs
+            )
+        )
+    )
+
+    @Test
+    fun dictionaryPresentationDataModel_Mapper_Equals() {
+        Assert.assertEquals(
+            dictionaryPresentationDataModelExpected,
+            DictionaryPresentationDataModel.Mapper.map(listOf(searchDtoActual))
+        )
+    }
+
+    @Test
+    fun dictionaryPresentationDataModel_Mapper_NotEquals() {
+        Assert.assertNotEquals(
+            dictionaryPresentationDataModelNotExpected,
+            DictionaryPresentationDataModel.Mapper.map(listOf(searchDtoActual))
+        )
+    }
+
+    @Test
+    fun dictionaryPresentationDataModel_Mapper_ArrayEquals() {
+        Assert.assertArrayEquals(
+            dictionaryPresentationDataModelExpected.translatedWords?.toTypedArray(),
+            DictionaryPresentationDataModel.Mapper.map(listOf(searchDtoActual)).translatedWords?.toTypedArray()
+        )
+    }
+
+    @Test
+    fun dictionaryPresentationDataModel_Mapper_assertNull() {
+        val searchDto = SearchDto(
+            id = null,
+            word = null,
+            meanings = null,
+            savedTime = null
+        )
+        Assert.assertNull(
+            DictionaryPresentationDataModel.Mapper.map(listOf(searchDto)).translatedWords?.first()?.id
+        )
+    }
+
+    @Test
+    fun dictionaryPresentationDataModel_Mapper_assertNotNull() {
+        val searchDto = SearchDto(
+            id = null,
+            word = null,
+            meanings = null,
+            savedTime = null
+        )
+        Assert.assertNotNull(
+            DictionaryPresentationDataModel.Mapper.map(listOf(searchDto))
+        )
+    }
+
+    @Test
+    fun dictionaryPresentationDataModel_Mapper_assertNotSame() {
+        Assert.assertNotSame(
+            dictionaryPresentationDataModelExpected,
+            DictionaryPresentationDataModel.Mapper.map(listOf(searchDtoActual))
+        )
+    }
+}

--- a/model/src/test/java/ru/androidlearning/model/StorageConvertersTest.kt
+++ b/model/src/test/java/ru/androidlearning/model/StorageConvertersTest.kt
@@ -1,0 +1,81 @@
+package ru.androidlearning.model
+
+import org.junit.Assert
+import org.junit.Test
+import ru.androidlearning.model.repository.datasource.local.storage.StorageConverters
+
+class StorageConvertersTest {
+
+    private val meaningsOne = Meanings(
+        id = 1,
+        partOfSpeechCode = "n",
+        translation = Translation(
+            text = "TranslatedWord",
+            note = "Test note"
+        ),
+        previewUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=96&h=72",
+        imageUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=640&h=480",
+        transcription = "ˈteɪbl",
+        soundUrl = "//d2fmfepycn0xw0.cloudfront.net?gender=male&accent=british&text=table"
+    )
+
+    private val meaningsTwo = Meanings(
+        id = 2,
+        partOfSpeechCode = "n",
+        translation = Translation(
+            text = "TranslatedWord2",
+            note = "Test note2"
+        ),
+        previewUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=96&h=72",
+        imageUrl = "//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w=640&h=480",
+        transcription = "ˈteɪbl",
+        soundUrl = "//d2fmfepycn0xw0.cloudfront.net?gender=male&accent=british&text=table"
+    )
+
+    private val meaningsOriginal = listOf(meaningsOne, meaningsTwo)
+    private val jsonOriginal =
+        "[{\"id\":1,\"partOfSpeechCode\":\"n\",\"translation\":{\"text\":\"TranslatedWord\",\"note\":\"Test note\"},\"previewUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d96\\u0026h\\u003d72\",\"imageUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d640\\u0026h\\u003d480\",\"transcription\":\"ˈteɪbl\",\"soundUrl\":\"//d2fmfepycn0xw0.cloudfront.net?gender\\u003dmale\\u0026accent\\u003dbritish\\u0026text\\u003dtable\"},{\"id\":2,\"partOfSpeechCode\":\"n\",\"translation\":{\"text\":\"TranslatedWord2\",\"note\":\"Test note2\"},\"previewUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d96\\u0026h\\u003d72\",\"imageUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d640\\u0026h\\u003d480\",\"transcription\":\"ˈteɪbl\",\"soundUrl\":\"//d2fmfepycn0xw0.cloudfront.net?gender\\u003dmale\\u0026accent\\u003dbritish\\u0026text\\u003dtable\"}]"
+
+    private val storageConverters by lazy { StorageConverters() }
+
+    @Test
+    fun storageConverters_directlyConverts_assertEquals() {
+        val json = storageConverters.fromMeaningsToJson(meaningsOriginal)
+        val meaningsExpected = storageConverters.fromJsonToMeanings(json)
+        Assert.assertEquals(meaningsExpected, meaningsOriginal)
+    }
+
+    @Test
+    fun storageConverters_backConverts_assertEquals() {
+        val meanings = storageConverters.fromJsonToMeanings(jsonOriginal)
+        val jsonExpected = storageConverters.fromMeaningsToJson(meanings)
+        Assert.assertEquals(jsonExpected, jsonOriginal)
+    }
+
+    @Test
+    fun storageConverters_fromJsonToMeanings_assertEquals() {
+        val meaningsExpected = storageConverters.fromJsonToMeanings(jsonOriginal)
+        Assert.assertEquals(meaningsExpected, meaningsOriginal)
+    }
+
+    @Test
+    fun storageConverters_fromMeaningsToJson_assertEquals() {
+        val jsonExpected = storageConverters.fromMeaningsToJson(meaningsOriginal)
+        Assert.assertEquals(jsonExpected, jsonOriginal)
+    }
+
+    @Test
+    fun storageConverters_fromJsonToMeanings_assertNotEquals() {
+        val json =
+            "[{\"id\":2,\"partOfSpeechCode\":\"n\",\"translation\":{\"text\":\"TranslatedWord\",\"note\":\"Test note\"},\"previewUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d96\\u0026h\\u003d72\",\"imageUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d640\\u0026h\\u003d480\",\"transcription\":\"ˈteɪbl\",\"soundUrl\":\"//d2fmfepycn0xw0.cloudfront.net?gender\\u003dmale\\u0026accent\\u003dbritish\\u0026text\\u003dtable\"},{\"id\":2,\"partOfSpeechCode\":\"n\",\"translation\":{\"text\":\"TranslatedWord2\",\"note\":\"Test note2\"},\"previewUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d96\\u0026h\\u003d72\",\"imageUrl\":\"//d2zkmv5t5kao9.cloudfront.net/images/19b11a8848201a3250ebc16339329a79.jpeg?w\\u003d640\\u0026h\\u003d480\",\"transcription\":\"ˈteɪbl\",\"soundUrl\":\"//d2fmfepycn0xw0.cloudfront.net?gender\\u003dmale\\u0026accent\\u003dbritish\\u0026text\\u003dtable\"}]"
+        val meaningsExpected = storageConverters.fromJsonToMeanings(json)
+        Assert.assertNotEquals(meaningsExpected, meaningsOriginal)
+    }
+
+    @Test
+    fun storageConverters_fromMeaningsToJson_assertNotEquals() {
+        val meanings = listOf(meaningsOne)
+        val jsonExpected = storageConverters.fromMeaningsToJson(meanings)
+        Assert.assertNotEquals(jsonExpected, jsonOriginal)
+    }
+}

--- a/presentation/src/androidTest/java/ru/androidlearning/presentation/ExampleInstrumentedTest.kt
+++ b/presentation/src/androidTest/java/ru/androidlearning/presentation/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
-package ru.androidlearning.fragments
+package ru.androidlearning.presentation
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/presentation/src/test/java/ru/androidlearning/presentation/ExampleUnitTest.kt
+++ b/presentation/src/test/java/ru/androidlearning/presentation/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
-package ru.androidlearning.fragments
+package ru.androidlearning.presentation
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
Направляю на проверку домашнюю работу к уроку №1.
Для выполнения домашнего задания выбрал MVVM-приложение, разработанное на предыдущем курсе.
Создал 2 класса:
1)	DictionaryPresentationDataModelMapperTest – тестирование маппера данных (из Dto в DataModel)
В этом классе реализовал методы, предложенные в тексте практического задания. 
2)	StorageConvertersTest – тестирование методов конвертера (androidx.room.TypeConverters), используемого в классе DictionaryStorage
